### PR TITLE
Change package name to github.com/tanium/service to directly import it.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kardianos/service
+module github.com/tanium/service
 
 go 1.10
 


### PR DESCRIPTION
Without this change, this requires all dependent modules to `replace`
it, prohibiting it from reliably being used in an intermediate library.