### PR TITLE
Change all references to the old package name, call out in docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: github.com/kardianos/service
+go_import_path: github.com/tanium/service
 sudo: required
 
 go:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# service [![GoDoc](https://godoc.org/github.com/kardianos/service?status.svg)](https://godoc.org/github.com/kardianos/service)
+# service [![GoDoc](https://godoc.org/github.com/tanium/service?status.svg)](https://godoc.org/github.com/tanium/service)
+
+**NOTE** This is forked from github.com/kardianos/service
 
 service will install / un-install, start / stop, and run a program as a service (daemon).
 Currently supports Windows XP+, Linux/(systemd | Upstart | SysV), and OSX/Launchd.

--- a/example/logging/main.go
+++ b/example/logging/main.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/kardianos/service"
+	"github.com/tanium/service"
 )
 
 var logger service.Logger

--- a/example/runner/runner.go
+++ b/example/runner/runner.go
@@ -14,7 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/kardianos/service"
+	"github.com/tanium/service"
 )
 
 // Config is the runner app config structure.

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -8,7 +8,7 @@ package main
 import (
 	"log"
 
-	"github.com/kardianos/service"
+	"github.com/tanium/service"
 )
 
 var logger service.Logger

--- a/example/stopPause/main.go
+++ b/example/stopPause/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/kardianos/service"
+	"github.com/tanium/service"
 )
 
 var logger service.Logger

--- a/service.go
+++ b/service.go
@@ -5,6 +5,8 @@
 // Package service provides a simple way to create a system service.
 // Currently supports Windows, Linux/(systemd | Upstart | SysV), and OSX/Launchd.
 //
+// This is forked from http://github.com/kardianos/service.
+//
 // Windows controls services by setting up callbacks that is non-trivial. This
 // is very different then other systems. This package provides the same API
 // despite the substantial differences.
@@ -18,7 +20,7 @@
 //	import (
 //		"log"
 //
-//		"github.com/kardianos/service"
+//		"github.com/tanium/service"
 //	)
 //
 //	var logger service.Logger
@@ -59,7 +61,7 @@
 //			logger.Error(err)
 //		}
 //	}
-package service // import "github.com/kardianos/service"
+package service // import "github.com/tanium/service"
 
 import (
 	"errors"

--- a/service_su_test.go
+++ b/service_su_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kardianos/service"
+	"github.com/tanium/service"
 )
 
 const runAsServiceArg = "RunThisAsService"

--- a/service_test.go
+++ b/service_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kardianos/service"
+	"github.com/tanium/service"
 )
 
 func TestRunInterrupt(t *testing.T) {


### PR DESCRIPTION
The _test.go references to the original package name will propagate to
downstream modules. Convert all references to the original lib to the
forked lib.

However, also add back attribution in the README and package docs.