### PR TITLE
Use ListServices to check if service is not installed

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -294,7 +294,17 @@ func (ws *windowsService) Status() (Status, error) {
 		if err.Error() == "The specified service does not exist as an installed service." {
 			return StatusUnknown, ErrNotInstalled
 		}
-		return StatusUnknown, err
+		// Enumerate all services to detect ErrNotInstalled for non-English languages.
+		services, err := m.ListServices()
+		if err != nil {
+			return StatusUnknown, err
+		}
+		for service := range services {
+			if service == ws.Name {
+				return StatusUnknown, err
+			}
+		}
+		return StatusUnknown, ErrNotInstalled
 	}
 	defer s.Close()
 


### PR DESCRIPTION
Checking the error text does not work for non-English installs of Windows.

I will also look at fixing this by exposing the error code from `m.OpenService`