### PR TITLE
use error code to detect windows service not installed

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"golang.org/x/sys/windows/registry"
@@ -20,6 +21,8 @@ import (
 )
 
 const version = "windows-service"
+
+const errnoServiceDoesNotExist syscall.Errno = 1060
 
 type windowsService struct {
 	i Interface
@@ -291,7 +294,7 @@ func (ws *windowsService) Status() (Status, error) {
 
 	s, err := m.OpenService(ws.Name)
 	if err != nil {
-		if err.Error() == "The specified service does not exist as an installed service." {
+		if errno, ok := err.(syscall.Errno); ok && errno == errnoServiceDoesNotExist {
 			return StatusUnknown, ErrNotInstalled
 		}
 		return StatusUnknown, err


### PR DESCRIPTION
The error string is localized on non-English Windows installs.

On Windows, the `Status` method calls windows/svc/[mgr.OpenService](https://github.com/golang/sys/blob/b64e53b001e413bd5067f36d4e439eded3827374/windows/svc/mgr/mgr.go#L161), which calls sys/[windows.OpenService](https://github.com/golang/sys/blob/b64e53b001e413bd5067f36d4e439eded3827374/windows/zsyscall_windows.go#L862), which calls [syscall.Syscall](https://golang.org/pkg/syscall/#Syscall), which returns the [Errno](https://golang.org/pkg/syscall/#Errno).